### PR TITLE
changes wait_time definition to count down until next resource is allowed

### DIFF
--- a/lib/simple_throttle.rb
+++ b/lib/simple_throttle.rb
@@ -133,7 +133,7 @@ class SimpleThrottle
       first = redis_client.lindex(redis_key, 0).to_f / 1000.0
       delta = Time.now.to_f - first
       delta = 0.0 if delta < 0
-      delta
+      ttl - delta
     end
   end
 

--- a/spec/simple_throttle_spec.rb
+++ b/spec/simple_throttle_spec.rb
@@ -76,4 +76,3 @@ describe SimpleThrottle do
     expect(throttle.allowed!).to eq true
   end
 end
-

--- a/spec/simple_throttle_spec.rb
+++ b/spec/simple_throttle_spec.rb
@@ -20,9 +20,10 @@ describe SimpleThrottle do
     expect(throttle.peek).to eq 3
     expect(throttle.allowed!).to eq false
     expect(throttle.peek).to eq 3
-    wait_time = throttle.wait_time
-    expect(wait_time).to be > 0.0
-    expect(wait_time).to be <= 1.0
+    earlier_wait_time = throttle.wait_time
+    expect(earlier_wait_time).to be > 0.0
+    expect(earlier_wait_time).to be <= throttle.ttl
+    expect(earlier_wait_time).to be > throttle.wait_time
 
     expect(other_throttle.allowed!).to eq true
     expect(other_throttle.peek).to eq 1
@@ -75,3 +76,4 @@ describe SimpleThrottle do
     expect(throttle.allowed!).to eq true
   end
 end
+


### PR DESCRIPTION
## Overview
This changes the definition of `wait_time` to return a count down in seconds until the next call will be allowed.  `ttl - delta`