### PR TITLE
Fix peek method to return accurate value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.7
 
+## Fixed
+- Fixed peek method to return the correct value rather than the raw value from Redis.
 ### Changed
 - Updated repository location and gem owners
 

--- a/lib/simple_throttle.rb
+++ b/lib/simple_throttle.rb
@@ -157,7 +157,9 @@ class SimpleThrottle
   #
   # @return [Integer]
   def peek
-    current_size(false)
+    timestamps = redis_client.lrange(redis_key, 0, -1).collect(&:to_i)
+    min_timestamp = ((Time.now.to_f - ttl) * 1000).ceil
+    timestamps.count { |t| t > min_timestamp }
   end
 
   # Returns when the next resource call should be allowed. Note that this doesn't guarantee that

--- a/spec/simple_throttle_spec.rb
+++ b/spec/simple_throttle_spec.rb
@@ -29,6 +29,7 @@ describe SimpleThrottle do
 
     sleep(1.1)
 
+    expect(other_throttle.peek).to eq 0
     expect(throttle.allowed!).to eq true
     sleep(0.3)
     expect(throttle.allowed!).to eq true
@@ -37,8 +38,10 @@ describe SimpleThrottle do
     sleep(0.3)
     expect(throttle.allowed!).to eq false
     sleep(0.3)
+    expect(throttle.peek).to eq 2
     expect(throttle.allowed!).to eq true
     expect(throttle.allowed!).to eq false
+    expect(throttle.peek).to eq 3
   end
 
   it "should track an extra call if pause to recover is set" do


### PR DESCRIPTION
Value was being returned prior to garbage collection in Redis which meant it would not show the current capacity.